### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.5
-  - release
+  - tip
 
 before_install:
   - go get -u github.com/nbio/st

--- a/vinci.go
+++ b/vinci.go
@@ -34,13 +34,13 @@ func (v *Vinci) UseForwarder(forwarder http.Handler) *Vinci {
 
 // Use attaches a new middleware handler for incoming HTTP traffic.
 func (v *Vinci) Use(handler interface{}) *Vinci {
-	v.Layer.Use(handler)
+	v.Layer.Use("request", handler)
 	return v
 }
 
 // UsePhase attaches a new middleware handler to a specific phase.
 func (v *Vinci) UsePhase(phase string, handler interface{}) *Vinci {
-	v.Layer.UsePhase(phase, handler)
+	v.Layer.Use(phase, handler)
 	return v
 }
 


### PR DESCRIPTION
The travis versions contained `release` instead of `tip`. I'm not sure if this was simply a typo.
Concerning the code, `Layer` does not define a method `UsePhase` but simply `Use` which accepts a string. So the code was changed accordingly to fix the build.